### PR TITLE
Handle empty backup repeating time intervals gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Key is used as reference identifier for backup instances.
 Supported types: "disk", "blob", "kubernetes", "postgresql", "postgresql\_flexible"
 
 Common settings:
-- backup\_repeating\_time\_intervals: List of ISO8601 backup schedule intervals
+- backup\_repeating\_time\_intervals: List of ISO8601 backup schedule intervals (empty list handled gracefully)
 - default\_retention\_duration: Default retention period in ISO8601 format
 - time\_zone: Time zone for backup schedules
 - retention\_rules: List of retention rules with criteria and lifecycle
@@ -222,7 +222,7 @@ map(object({
     name = string
 
     # Common policy settings
-    backup_repeating_time_intervals = optional(list(string), [])
+    backup_repeating_time_intervals = optional(list(string), []) # Empty list is handled as null to avoid provider validation errors
     default_retention_duration      = optional(string, "P30D")
     time_zone                       = optional(string, "UTC")
 

--- a/main.aks_backup.tf
+++ b/main.aks_backup.tf
@@ -2,7 +2,7 @@
 resource "azurerm_data_protection_backup_policy_kubernetes_cluster" "this" {
   count = var.kubernetes_backup_policy_name != null ? 1 : 0
 
-  backup_repeating_time_intervals = var.backup_repeating_time_intervals
+  backup_repeating_time_intervals = length(var.backup_repeating_time_intervals) > 0 ? var.backup_repeating_time_intervals : null
   name                            = var.kubernetes_backup_policy_name
   resource_group_name             = var.resource_group_name
   vault_name                      = azurerm_data_protection_backup_vault.this.name

--- a/main.blob_backup.tf
+++ b/main.blob_backup.tf
@@ -4,7 +4,7 @@ resource "azurerm_data_protection_backup_policy_blob_storage" "this" {
 
   name                                   = each.value.name
   vault_id                               = azurerm_data_protection_backup_vault.this.id
-  backup_repeating_time_intervals        = each.value.backup_repeating_time_intervals
+  backup_repeating_time_intervals        = length(each.value.backup_repeating_time_intervals) > 0 ? each.value.backup_repeating_time_intervals : null
   operational_default_retention_duration = each.value.operational_default_retention_duration
   time_zone                              = each.value.time_zone
   vault_default_retention_duration       = each.value.vault_default_retention_duration

--- a/main.disk_backup.tf
+++ b/main.disk_backup.tf
@@ -2,7 +2,7 @@
 resource "azurerm_data_protection_backup_policy_disk" "this" {
   for_each = local.disk_policies
 
-  backup_repeating_time_intervals = each.value.backup_repeating_time_intervals
+  backup_repeating_time_intervals = length(each.value.backup_repeating_time_intervals) > 0 ? each.value.backup_repeating_time_intervals : null
   default_retention_duration      = each.value.default_retention_duration
   name                            = each.value.name
   vault_id                        = azurerm_data_protection_backup_vault.this.id

--- a/main.postgres_backup.tf
+++ b/main.postgres_backup.tf
@@ -2,7 +2,7 @@
 resource "azurerm_data_protection_backup_policy_postgresql" "this" {
   for_each = local.postgresql_policies
 
-  backup_repeating_time_intervals = each.value.backup_repeating_time_intervals
+  backup_repeating_time_intervals = length(each.value.backup_repeating_time_intervals) > 0 ? each.value.backup_repeating_time_intervals : null
   default_retention_duration      = each.value.default_retention_duration
   name                            = each.value.name
   resource_group_name             = var.resource_group_name

--- a/main.postgresflexible_backup.tf
+++ b/main.postgresflexible_backup.tf
@@ -2,7 +2,7 @@
 resource "azurerm_data_protection_backup_policy_postgresql_flexible_server" "this" {
   for_each = local.postgresql_flexible_policies
 
-  backup_repeating_time_intervals = each.value.backup_repeating_time_intervals
+  backup_repeating_time_intervals = length(each.value.backup_repeating_time_intervals) > 0 ? each.value.backup_repeating_time_intervals : null
   name                            = each.value.name
   vault_id                        = azurerm_data_protection_backup_vault.this.id
   time_zone                       = coalesce(each.value.time_zone, "UTC")

--- a/variables.tf
+++ b/variables.tf
@@ -158,7 +158,7 @@ variable "backup_policies" {
     name = string
 
     # Common policy settings
-    backup_repeating_time_intervals = optional(list(string), [])
+    backup_repeating_time_intervals = optional(list(string), []) # Empty list is handled as null to avoid provider validation errors
     default_retention_duration      = optional(string, "P30D")
     time_zone                       = optional(string, "UTC")
 
@@ -203,7 +203,7 @@ Key is used as reference identifier for backup instances.
 Supported types: "disk", "blob", "kubernetes", "postgresql", "postgresql_flexible"
 
 Common settings:
-- backup_repeating_time_intervals: List of ISO8601 backup schedule intervals
+- backup_repeating_time_intervals: List of ISO8601 backup schedule intervals (empty list handled gracefully)
 - default_retention_duration: Default retention period in ISO8601 format
 - time_zone: Time zone for backup schedules
 - retention_rules: List of retention rules with criteria and lifecycle


### PR DESCRIPTION
Based on the code changes we made to fix the provider issue with `backup_repeating_time_intervals`, here's the filled out PR template:

## Description

Fixed Azure provider validation error where `backup_repeating_time_intervals` attribute requires at least 1 item when an empty list is provided, but works correctly when the attribute is omitted entirely.

**Problem**: The Azure provider throws a validation error "Attribute backup_repeating_time_intervals requires 1 item minimum, but config has only 0 declared" when an empty list `[]` is explicitly passed, even though the attribute is marked as optional.

**Solution**: Updated all backup policy resources to use conditional logic that sets the attribute to `null` (omitting it) when the list is empty, and passes the actual list when it contains values:

```hcl
backup_repeating_time_intervals = length(each.value.backup_repeating_time_intervals) > 0 ? each.value.backup_repeating_time_intervals : null
```

**Files Modified**:
- main.blob_backup.tf
- main.disk_backup.tf 
- main.postgres_backup.tf
- main.postgresflexible_backup.tf
- main.aks_backup.tf
- variables.tf (updated documentation)

This ensures backwards compatibility while fixing the provider validation issue.

Fixes # 17

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ x ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
