### PR TITLE
Change backup interval from 4 hours to 6 hours

### DIFF
--- a/examples/blob_storage_backup/README.md
+++ b/examples/blob_storage_backup/README.md
@@ -97,7 +97,7 @@ module "backup_vault" {
     "blob-backup" = {
       type                                   = "blob"
       name                                   = "${module.naming.recovery_services_vault.name_unique}-backup-policy"
-      backup_repeating_time_intervals        = ["R/2024-09-17T06:33:16+00:00/PT4H"]
+      backup_repeating_time_intervals        = ["R/2024-09-17T06:33:16+00:00/PT6H"]
       operational_default_retention_duration = "P30D"
       vault_default_retention_duration       = "P90D"
       time_zone                              = "Central Standard Time"


### PR DESCRIPTION
Backup for Azure Blobs is limited to 5 per day. The 4 hour interval would lead to 6 backups per day and results in the ``UserErrorMaxSubmissionLimitReached`` error being triggered daily. Increasing the backup interval in this example prevents that limit from being reached.

[MS Learn reference](https://learn.microsoft.com/en-us/azure/backup/backup-azure-troubleshoot-blob-backup#usererrormaxsubmissionlimitreached)

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [X] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [X] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
