### PR TITLE
Restructure AKS backup configuration and improve variable validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,26 +124,6 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
-### <a name="input_backup_datasource_parameters"></a> [backup\_datasource\_parameters](#input\_backup\_datasource\_parameters)
-
-Description: Configuration for Kubernetes backup datasource parameters.
-
-Type:
-
-```hcl
-object({
-    excluded_namespaces              = optional(list(string), [])
-    included_namespaces              = optional(list(string), [])
-    excluded_resource_types          = optional(list(string), [])
-    included_resource_types          = optional(list(string), [])
-    label_selectors                  = optional(list(string), [])
-    cluster_scoped_resources_enabled = optional(bool, false)
-    volume_snapshot_enabled          = optional(bool, false)
-  })
-```
-
-Default: `null`
-
 ### <a name="input_backup_instances"></a> [backup\_instances](#input\_backup\_instances)
 
 Description: Map of backup instances to create. Each instance references a backup policy via backup\_policy\_key.
@@ -269,14 +249,6 @@ map(object({
 
 Default: `{}`
 
-### <a name="input_backup_repeating_time_intervals"></a> [backup\_repeating\_time\_intervals](#input\_backup\_repeating\_time\_intervals)
-
-Description: List of repeating time intervals for scheduling backups.
-
-Type: `list(string)`
-
-Default: `[]`
-
 ### <a name="input_cross_region_restore_enabled"></a> [cross\_region\_restore\_enabled](#input\_cross\_region\_restore\_enabled)
 
 Description: Whether to enable cross-region restore for the Backup Vault. Can only be enabled with GeoRedundant redundancy.
@@ -303,21 +275,6 @@ object({
     user_assigned_identity = optional(object({
       resource_id = string
     }), null)
-  })
-```
-
-Default: `null`
-
-### <a name="input_default_retention_life_cycle"></a> [default\_retention\_life\_cycle](#input\_default\_retention\_life\_cycle)
-
-Description: Default retention life cycle configuration for AKS backups.
-
-Type:
-
-```hcl
-object({
-    data_store_type = optional(string, "OperationalStore")
-    duration        = optional(string, "P14D")
   })
 ```
 
@@ -374,51 +331,6 @@ Description: Immutability state: Disabled, Locked, or Unlocked.
 Type: `string`
 
 Default: `"Disabled"`
-
-### <a name="input_kubernetes_backup_instance_name"></a> [kubernetes\_backup\_instance\_name](#input\_kubernetes\_backup\_instance\_name)
-
-Description: Name for the AKS backup instance when using direct configuration.
-
-Type: `string`
-
-Default: `null`
-
-### <a name="input_kubernetes_backup_policy_name"></a> [kubernetes\_backup\_policy\_name](#input\_kubernetes\_backup\_policy\_name)
-
-Description: Name for the AKS backup policy when using direct configuration.
-
-Type: `string`
-
-Default: `null`
-
-### <a name="input_kubernetes_cluster_id"></a> [kubernetes\_cluster\_id](#input\_kubernetes\_cluster\_id)
-
-Description: Resource ID of the AKS cluster to back up when using direct configuration.
-
-Type: `string`
-
-Default: `null`
-
-### <a name="input_kubernetes_retention_rules"></a> [kubernetes\_retention\_rules](#input\_kubernetes\_retention\_rules)
-
-Description: List of retention rules for AKS backups when using direct configuration.
-
-Type:
-
-```hcl
-list(object({
-    name              = string
-    priority          = number
-    absolute_criteria = optional(string)
-    days_of_week      = optional(list(string))
-    months_of_year    = optional(list(string))
-    weeks_of_month    = optional(list(string))
-    data_store_type   = optional(string, "OperationalStore")
-    duration          = string
-  }))
-```
-
-Default: `[]`
 
 ### <a name="input_lock"></a> [lock](#input\_lock)
 
@@ -512,14 +424,6 @@ map(object({
 
 Default: `{}`
 
-### <a name="input_snapshot_resource_group_name"></a> [snapshot\_resource\_group\_name](#input\_snapshot\_resource\_group\_name)
-
-Description: Resource group name for AKS volume snapshots when using direct configuration.
-
-Type: `string`
-
-Default: `null`
-
 ### <a name="input_soft_delete"></a> [soft\_delete](#input\_soft\_delete)
 
 Description: The state of soft delete for this Backup Vault. Valid options: AlwaysOn, Off, On. Defaults to On.  
@@ -536,14 +440,6 @@ Description: (Optional) Tags of the resource.
 Type: `map(string)`
 
 Default: `null`
-
-### <a name="input_time_zone"></a> [time\_zone](#input\_time\_zone)
-
-Description: Time zone for backup scheduling when using direct configuration.
-
-Type: `string`
-
-Default: `"UTC"`
 
 ### <a name="input_timeout_create"></a> [timeout\_create](#input\_timeout\_create)
 

--- a/examples/aks_backup/README.md
+++ b/examples/aks_backup/README.md
@@ -138,47 +138,62 @@ module "backup_vault" {
   name                = "${module.naming.recovery_services_vault.name_unique}-vault"
   redundancy          = "LocallyRedundant"
   resource_group_name = azurerm_resource_group.example.name
-  # Specify backup datasource parameters
-  backup_datasource_parameters = {
-    excluded_namespaces              = ["kube-system", "kube-public"]
-    included_namespaces              = ["default", "app-namespace"]
-    cluster_scoped_resources_enabled = true
-    volume_snapshot_enabled          = true
+  backup_instances = {
+    aks = {
+      type                         = "kubernetes"
+      name                         = "${module.naming.kubernetes_cluster.name_unique}-backup-instance"
+      backup_policy_key            = "aks"
+      kubernetes_cluster_id        = azurerm_kubernetes_cluster.example.id
+      snapshot_resource_group_name = azurerm_resource_group.snap.name
+      backup_datasource_parameters = {
+        excluded_namespaces              = ["kube-system", "kube-public"]
+        included_namespaces              = ["default", "app-namespace"]
+        cluster_scoped_resources_enabled = true
+        volume_snapshot_enabled          = true
+      }
+    }
   }
-  backup_repeating_time_intervals = ["R/2024-12-01T02:30:00+00:00/P1W"]
-  # AKS default retention configuration
-  default_retention_life_cycle = {
-    data_store_type = "OperationalStore"
-    duration        = "P14D"
+  backup_policies = {
+    aks = {
+      type = "kubernetes"
+      name = "${module.naming.kubernetes_cluster.name_unique}-policy"
+
+      backup_repeating_time_intervals = ["R/2024-12-01T02:30:00+00:00/P1W"]
+      time_zone                       = "UTC"
+
+      default_retention_life_cycle = {
+        data_store_type = "OperationalStore"
+        duration        = "P14D"
+      }
+
+      retention_rules = [
+        {
+          name     = "Weekly"
+          priority = 25
+          duration = "P84D"
+          criteria = [
+            {
+              absolute_criteria = "FirstOfWeek"
+            }
+          ]
+        },
+        {
+          name     = "Monthly"
+          priority = 20
+          duration = "P365D"
+          criteria = [
+            {
+              absolute_criteria = "FirstOfMonth"
+            }
+          ]
+        }
+      ]
+    }
   }
   enable_telemetry = true
-  # AKS backup instance configuration
-  kubernetes_backup_instance_name = "${module.naming.kubernetes_cluster.name_unique}-backup-instance"
-  # AKS backup policy configuration
-  kubernetes_backup_policy_name = "${module.naming.kubernetes_cluster.name_unique}-policy"
-  kubernetes_cluster_id         = azurerm_kubernetes_cluster.example.id
-  # Additional retention rules
-  kubernetes_retention_rules = [
-    {
-      name              = "Weekly"
-      priority          = 25
-      absolute_criteria = "FirstOfWeek"
-      data_store_type   = "OperationalStore"
-      duration          = "P84D"
-    },
-    {
-      name              = "Monthly"
-      priority          = 20
-      absolute_criteria = "FirstOfMonth"
-      data_store_type   = "OperationalStore"
-      duration          = "P365D"
-    }
-  ]
   managed_identities = {
     system_assigned = true
   }
-  snapshot_resource_group_name = azurerm_resource_group.snap.name
-  time_zone                    = "UTC"
 
   depends_on = [time_sleep.wait_for_extension]
 }

--- a/examples/aks_backup/main.tf
+++ b/examples/aks_backup/main.tf
@@ -131,47 +131,62 @@ module "backup_vault" {
   name                = "${module.naming.recovery_services_vault.name_unique}-vault"
   redundancy          = "LocallyRedundant"
   resource_group_name = azurerm_resource_group.example.name
-  # Specify backup datasource parameters
-  backup_datasource_parameters = {
-    excluded_namespaces              = ["kube-system", "kube-public"]
-    included_namespaces              = ["default", "app-namespace"]
-    cluster_scoped_resources_enabled = true
-    volume_snapshot_enabled          = true
+  backup_instances = {
+    aks = {
+      type                         = "kubernetes"
+      name                         = "${module.naming.kubernetes_cluster.name_unique}-backup-instance"
+      backup_policy_key            = "aks"
+      kubernetes_cluster_id        = azurerm_kubernetes_cluster.example.id
+      snapshot_resource_group_name = azurerm_resource_group.snap.name
+      backup_datasource_parameters = {
+        excluded_namespaces              = ["kube-system", "kube-public"]
+        included_namespaces              = ["default", "app-namespace"]
+        cluster_scoped_resources_enabled = true
+        volume_snapshot_enabled          = true
+      }
+    }
   }
-  backup_repeating_time_intervals = ["R/2024-12-01T02:30:00+00:00/P1W"]
-  # AKS default retention configuration
-  default_retention_life_cycle = {
-    data_store_type = "OperationalStore"
-    duration        = "P14D"
+  backup_policies = {
+    aks = {
+      type = "kubernetes"
+      name = "${module.naming.kubernetes_cluster.name_unique}-policy"
+
+      backup_repeating_time_intervals = ["R/2024-12-01T02:30:00+00:00/P1W"]
+      time_zone                       = "UTC"
+
+      default_retention_life_cycle = {
+        data_store_type = "OperationalStore"
+        duration        = "P14D"
+      }
+
+      retention_rules = [
+        {
+          name     = "Weekly"
+          priority = 25
+          duration = "P84D"
+          criteria = [
+            {
+              absolute_criteria = "FirstOfWeek"
+            }
+          ]
+        },
+        {
+          name     = "Monthly"
+          priority = 20
+          duration = "P365D"
+          criteria = [
+            {
+              absolute_criteria = "FirstOfMonth"
+            }
+          ]
+        }
+      ]
+    }
   }
   enable_telemetry = true
-  # AKS backup instance configuration
-  kubernetes_backup_instance_name = "${module.naming.kubernetes_cluster.name_unique}-backup-instance"
-  # AKS backup policy configuration
-  kubernetes_backup_policy_name = "${module.naming.kubernetes_cluster.name_unique}-policy"
-  kubernetes_cluster_id         = azurerm_kubernetes_cluster.example.id
-  # Additional retention rules
-  kubernetes_retention_rules = [
-    {
-      name              = "Weekly"
-      priority          = 25
-      absolute_criteria = "FirstOfWeek"
-      data_store_type   = "OperationalStore"
-      duration          = "P84D"
-    },
-    {
-      name              = "Monthly"
-      priority          = 20
-      absolute_criteria = "FirstOfMonth"
-      data_store_type   = "OperationalStore"
-      duration          = "P365D"
-    }
-  ]
   managed_identities = {
     system_assigned = true
   }
-  snapshot_resource_group_name = azurerm_resource_group.snap.name
-  time_zone                    = "UTC"
 
   depends_on = [time_sleep.wait_for_extension]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,8 @@ locals {
   disk_instances = { for k, v in var.backup_instances : k => v if v.type == "disk" }
   # Organize backup policies by type
   disk_policies                      = { for k, v in var.backup_policies : k => v if v.type == "disk" }
+  kubernetes_instances               = { for k, v in var.backup_instances : k => v if v.type == "kubernetes" }
+  kubernetes_policies                = { for k, v in var.backup_policies : k => v if v.type == "kubernetes" }
   postgresql_flexible_instances      = { for k, v in var.backup_instances : k => v if v.type == "postgresql_flexible" }
   postgresql_flexible_policies       = { for k, v in var.backup_policies : k => v if v.type == "postgresql_flexible" }
   postgresql_instances               = { for k, v in var.backup_instances : k => v if v.type == "postgresql" }

--- a/main.aks_backup.tf
+++ b/main.aks_backup.tf
@@ -1,8 +1,8 @@
 # AKS/Kubernetes Backup Policies
 resource "azapi_resource" "backup_policy_kubernetes_cluster" {
-  count = var.kubernetes_backup_policy_name != null ? 1 : 0
+  for_each = local.kubernetes_policies
 
-  name      = var.kubernetes_backup_policy_name
+  name      = each.value.name
   parent_id = azapi_resource.backup_vault.id
   type      = "Microsoft.DataProtection/backupVaults/backupPolicies@2025-07-01"
   body = {
@@ -14,7 +14,7 @@ resource "azapi_resource" "backup_policy_kubernetes_cluster" {
         trigger = {
           objectType = "ScheduleBasedTriggerContext"
           schedule = {
-            repeatingTimeIntervals = var.backup_repeating_time_intervals
+            repeatingTimeIntervals = each.value.backup_repeating_time_intervals
           }
           taggingCriteria = concat([
             {
@@ -25,7 +25,7 @@ resource "azapi_resource" "backup_policy_kubernetes_cluster" {
               }
             }
             ], [
-            for rr in var.kubernetes_retention_rules : {
+            for rr in each.value.retention_rules : {
               isDefault       = false
               taggingPriority = rr.priority
               tagInfo = {
@@ -33,7 +33,7 @@ resource "azapi_resource" "backup_policy_kubernetes_cluster" {
               }
             }
           ])
-          timezone = var.time_zone
+          timezone = each.value.time_zone
         }
         backupParameters = {
           objectType = "AzureBackupParams"
@@ -49,23 +49,23 @@ resource "azapi_resource" "backup_policy_kubernetes_cluster" {
         isDefault  = true
         objectType = "AzureRetentionRule"
         lifeCycle = [{
-          dataStoreType = var.default_retention_life_cycle != null ? var.default_retention_life_cycle.data_store_type : "OperationalStore"
-          duration      = var.default_retention_life_cycle != null ? var.default_retention_life_cycle.duration : "P14D"
+          dataStoreType = each.value.default_retention_life_cycle != null ? each.value.default_retention_life_cycle.data_store_type : "OperationalStore"
+          duration      = each.value.default_retention_life_cycle != null ? each.value.default_retention_life_cycle.duration : "P14D"
         }]
       }
-      retentionRules = [for rr in var.kubernetes_retention_rules : {
+      retentionRules = [for rr in each.value.retention_rules : {
         name       = rr.name
         priority   = rr.priority
         objectType = "AzureRetentionRule"
         criteria = {
-          absoluteCriteria = try(rr.absolute_criteria, null)
-          daysOfWeek       = try(rr.days_of_week, null)
-          monthsOfYear     = try(rr.months_of_year, null)
-          weeksOfMonth     = try(rr.weeks_of_month, null)
+          absoluteCriteria = try(rr.criteria[0].absolute_criteria, null)
+          daysOfWeek       = try(rr.criteria[0].days_of_week, null)
+          monthsOfYear     = try(rr.criteria[0].months_of_year, null)
+          weeksOfMonth     = try(rr.criteria[0].weeks_of_month, null)
         }
         lifeCycle = [{
-          dataStoreType = try(rr.data_store_type, "OperationalStore")
-          duration      = rr.duration
+          dataStoreType = try(rr.life_cycle[0].data_store_type, "OperationalStore")
+          duration      = try(rr.life_cycle[0].duration, rr.duration, "P30D")
         }]
       }]
       datasourceTypes = ["Microsoft.ContainerService/managedClusters"]
@@ -87,38 +87,38 @@ resource "azapi_resource" "backup_policy_kubernetes_cluster" {
 }
 
 resource "azapi_resource" "backup_instance_kubernetes_cluster" {
-  count = var.kubernetes_backup_instance_name != null ? 1 : 0
+  for_each = local.kubernetes_instances
 
   location  = var.location
-  name      = var.kubernetes_backup_instance_name
+  name      = each.value.name
   parent_id = azapi_resource.backup_vault.id
   type      = "Microsoft.DataProtection/backupVaults/backupInstances@2025-07-01"
   body = {
     properties = {
-      policyId     = length(azapi_resource.backup_policy_kubernetes_cluster) > 0 ? azapi_resource.backup_policy_kubernetes_cluster[0].id : null
-      friendlyName = var.kubernetes_backup_instance_name
+      policyId     = azapi_resource.backup_policy_kubernetes_cluster[each.value.backup_policy_key].id
+      friendlyName = each.value.name
       objectType   = "BackupInstance"
       dataSourceInfo = {
         objectType       = "DatasourceInfo"
-        resourceId       = var.kubernetes_cluster_id
+        resourceId       = each.value.kubernetes_cluster_id
         datasourceType   = "Microsoft.ContainerService/managedClusters"
         resourceLocation = var.location
       }
       datasourceAuthCredentials = null
       dataSourceSetInfo = {
         objectType = "DatasourceSetInfo"
-        resourceId = var.kubernetes_cluster_id
+        resourceId = each.value.kubernetes_cluster_id
       }
       datasourceParameters = {
         objectType                    = "KubernetesClusterBackupDatasourceParameters"
-        clusterScopedResourcesEnabled = try(var.backup_datasource_parameters.cluster_scoped_resources_enabled, false)
-        excludedNamespaces            = try(var.backup_datasource_parameters.excluded_namespaces, [])
-        excludedResourceTypes         = try(var.backup_datasource_parameters.excluded_resource_types, [])
-        includedNamespaces            = try(var.backup_datasource_parameters.included_namespaces, [])
-        includedResourceTypes         = try(var.backup_datasource_parameters.included_resource_types, [])
-        labelSelectors                = try(var.backup_datasource_parameters.label_selectors, [])
-        volumeSnapshotEnabled         = try(var.backup_datasource_parameters.volume_snapshot_enabled, false)
-        snapshotResourceGroupName     = var.snapshot_resource_group_name
+        clusterScopedResourcesEnabled = try(each.value.backup_datasource_parameters.cluster_scoped_resources_enabled, false)
+        excludedNamespaces            = try(each.value.backup_datasource_parameters.excluded_namespaces, [])
+        excludedResourceTypes         = try(each.value.backup_datasource_parameters.excluded_resource_types, [])
+        includedNamespaces            = try(each.value.backup_datasource_parameters.included_namespaces, [])
+        includedResourceTypes         = try(each.value.backup_datasource_parameters.included_resource_types, [])
+        labelSelectors                = try(each.value.backup_datasource_parameters.label_selectors, [])
+        volumeSnapshotEnabled         = try(each.value.backup_datasource_parameters.volume_snapshot_enabled, false)
+        snapshotResourceGroupName     = each.value.snapshot_resource_group_name
       }
       validationType = "ShallowValidation"
     }
@@ -146,8 +146,12 @@ resource "azapi_resource" "backup_instance_kubernetes_cluster" {
     ]
 
     precondition {
-      condition     = var.kubernetes_cluster_id != null
-      error_message = "kubernetes_cluster_id must be provided for direct AKS backup instance."
+      condition     = each.value.kubernetes_cluster_id != null
+      error_message = "kubernetes_cluster_id must be provided for kubernetes backup instance '${each.key}'."
+    }
+    precondition {
+      condition     = each.value.snapshot_resource_group_name != null
+      error_message = "snapshot_resource_group_name must be provided for kubernetes backup instance '${each.key}'."
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -49,21 +49,6 @@ variable "resource_group_name" {
   description = "The resource group where the resources will be deployed."
 }
 
-# Direct AKS/Kubernetes backup configuration variables
-variable "backup_datasource_parameters" {
-  type = object({
-    excluded_namespaces              = optional(list(string), [])
-    included_namespaces              = optional(list(string), [])
-    excluded_resource_types          = optional(list(string), [])
-    included_resource_types          = optional(list(string), [])
-    label_selectors                  = optional(list(string), [])
-    cluster_scoped_resources_enabled = optional(bool, false)
-    volume_snapshot_enabled          = optional(bool, false)
-  })
-  default     = null
-  description = "Configuration for Kubernetes backup datasource parameters."
-}
-
 # Backup Instances Configuration
 variable "backup_instances" {
   type = map(object({
@@ -149,6 +134,13 @@ DESCRIPTION
     ])
     error_message = "All backup instance names must be between 5 and 50 characters long."
   }
+  validation {
+    condition = alltrue([
+      for instance in var.backup_instances :
+      instance.type != "kubernetes" ? true : (instance.kubernetes_cluster_id != null && instance.snapshot_resource_group_name != null)
+    ])
+    error_message = "Kubernetes backup instances must provide kubernetes_cluster_id and snapshot_resource_group_name."
+  }
 }
 
 # Backup Policies Configuration
@@ -220,12 +212,32 @@ DESCRIPTION
     ])
     error_message = "All backup policies must have a valid type: disk, blob, kubernetes, postgresql, or postgresql_flexible."
   }
-}
-
-variable "backup_repeating_time_intervals" {
-  type        = list(string)
-  default     = []
-  description = "List of repeating time intervals for scheduling backups."
+  validation {
+    condition = alltrue([
+      for policy in var.backup_policies :
+      policy.type != "kubernetes" ? true : length(policy.backup_repeating_time_intervals) > 0
+    ])
+    error_message = "Kubernetes backup policies must set backup_repeating_time_intervals (at least one interval)."
+  }
+  validation {
+    condition = alltrue([
+      for policy in var.backup_policies :
+      policy.type != "kubernetes" ? true : alltrue([for rr in policy.retention_rules : length(rr.criteria) == 1])
+    ])
+    error_message = "Kubernetes backup policies require each retention_rules[*].criteria to contain exactly one entry."
+  }
+  validation {
+    condition = alltrue([
+      for policy in var.backup_policies :
+      policy.type != "kubernetes" ? true : alltrue([
+        for rr in policy.retention_rules : (
+          try(length(rr.criteria[0].days_of_month), 0) == 0 &&
+          try(length(rr.criteria[0].scheduled_backup_times), 0) == 0
+        )
+      ])
+    ])
+    error_message = "Kubernetes retention_rules.criteria does not support days_of_month or scheduled_backup_times in this module."
+  }
 }
 
 variable "cross_region_restore_enabled" {
@@ -259,15 +271,6 @@ Customer-managed key configuration for encrypting the Backup Vault, following th
 - key_version: (Optional) Specific key version. If omitted, the service uses the latest.
 - user_assigned_identity: (Optional) For future compatibility where UA-MI is supported.
 DESCRIPTION
-}
-
-variable "default_retention_life_cycle" {
-  type = object({
-    data_store_type = optional(string, "OperationalStore")
-    duration        = optional(string, "P14D")
-  })
-  default     = null
-  description = "Default retention life cycle configuration for AKS backups."
 }
 
 variable "diagnostic_settings" {
@@ -336,39 +339,6 @@ variable "immutability" {
     condition     = contains(["Disabled", "Locked", "Unlocked"], var.immutability)
     error_message = "immutability must be one of: Disabled, Locked, Unlocked."
   }
-}
-
-variable "kubernetes_backup_instance_name" {
-  type        = string
-  default     = null
-  description = "Name for the AKS backup instance when using direct configuration."
-}
-
-variable "kubernetes_backup_policy_name" {
-  type        = string
-  default     = null
-  description = "Name for the AKS backup policy when using direct configuration."
-}
-
-variable "kubernetes_cluster_id" {
-  type        = string
-  default     = null
-  description = "Resource ID of the AKS cluster to back up when using direct configuration."
-}
-
-variable "kubernetes_retention_rules" {
-  type = list(object({
-    name              = string
-    priority          = number
-    absolute_criteria = optional(string)
-    days_of_week      = optional(list(string))
-    months_of_year    = optional(list(string))
-    weeks_of_month    = optional(list(string))
-    data_store_type   = optional(string, "OperationalStore")
-    duration          = string
-  }))
-  default     = []
-  description = "List of retention rules for AKS backups when using direct configuration."
 }
 
 variable "lock" {
@@ -448,12 +418,6 @@ variable "role_assignments" {
   nullable    = false
 }
 
-variable "snapshot_resource_group_name" {
-  type        = string
-  default     = null
-  description = "Resource group name for AKS volume snapshots when using direct configuration."
-}
-
 variable "soft_delete" {
   type        = string
   default     = "Off"
@@ -473,12 +437,6 @@ variable "tags" {
   type        = map(string)
   default     = null
   description = "(Optional) Tags of the resource."
-}
-
-variable "time_zone" {
-  type        = string
-  default     = "UTC"
-  description = "Time zone for backup scheduling when using direct configuration."
 }
 
 # Timeouts Configuration


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #48
Closes #48 
-->

This PR fixes AKS (“kubernetes”) backups not being created when using the backup_policies / backup_instances maps.

Previously, AKS backups were implemented as a single-instance/single-policy flow (direct AKS variables + count), so kubernetes entries in the maps were effectively ignored. This change aligns AKS with the existing module pattern used for disk/blob/postgres by routing kubernetes entries via locals and creating resources with for_each.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->

