### PR TITLE
fix: remove azapi provider and integrate backup instance configuration in AKS backup example

### DIFF
--- a/examples/aks_backup/README.md
+++ b/examples/aks_backup/README.md
@@ -9,10 +9,6 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.4"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -28,8 +24,6 @@ provider "azurerm" {
   features {}
   storage_use_azuread = true
 }
-
-provider "azapi" {}
 
 data "azurerm_client_config" "current" {}
 
@@ -140,10 +134,7 @@ resource "azurerm_role_assignment" "extension_storage_access" {
 }
 
 # ---------------------------------------------------------------------------
-# Backup vault + policy (phase 1 — vault MSI must exist before RBAC below)
-# The backup instance is intentionally omitted here so that all required RBAC
-# and the trusted-access binding can be established before the instance is
-# created.  See the azapi_resource.backup_instance block further below.
+# Backup vault + policy + backup instance
 # ---------------------------------------------------------------------------
 module "backup_vault" {
   source = "../../"
@@ -153,6 +144,24 @@ module "backup_vault" {
   name                = "${module.naming.recovery_services_vault.name_unique}-vault"
   redundancy          = "LocallyRedundant"
   resource_group_name = azurerm_resource_group.example.name
+  backup_instances = {
+    aks = {
+      type                         = "kubernetes"
+      name                         = "${module.naming.kubernetes_cluster.name_unique}-backup-instance"
+      backup_policy_key            = "aks"
+      kubernetes_cluster_id        = azurerm_kubernetes_cluster.example.id
+      snapshot_resource_group_name = azurerm_resource_group.snap.name
+      backup_datasource_parameters = {
+        excluded_namespaces              = ["kube-system", "kube-public", "kube-node-lease"]
+        excluded_resource_types          = []
+        included_namespaces              = []
+        included_resource_types          = []
+        label_selectors                  = []
+        cluster_scoped_resources_enabled = true
+        volume_snapshot_enabled          = true
+      }
+    }
+  }
   backup_policies = {
     aks = {
       type = "kubernetes"
@@ -192,7 +201,6 @@ module "backup_vault" {
 
 # ---------------------------------------------------------------------------
 # RBAC — all roles the vault MSI and AKS MSI need for backup operations
-# These must be in place before the backup instance is created.
 # ---------------------------------------------------------------------------
 
 # Grants the backup vault's managed identity operator access to the AKS cluster
@@ -241,90 +249,6 @@ resource "azurerm_role_assignment" "required_roles" {
   scope                = each.value.scope
   role_definition_name = each.value.role
 }
-
-# Allow RBAC assignments to propagate across Azure AD before creating the
-# backup instance — typically takes up to 2 minutes.
-resource "time_sleep" "wait_for_rbac" {
-  create_duration = "2m"
-
-  depends_on = [
-    azurerm_kubernetes_cluster_trusted_access_role_binding.backup_access,
-    azurerm_role_assignment.extension_storage_access,
-    azurerm_role_assignment.required_roles,
-  ]
-}
-
-# ---------------------------------------------------------------------------
-# Backup instance (phase 2 — created only after all RBAC is in place)
-# ---------------------------------------------------------------------------
-resource "azapi_resource" "backup_instance" {
-  location  = azurerm_resource_group.example.location
-  name      = "${module.naming.kubernetes_cluster.name_unique}-backup-instance"
-  parent_id = module.backup_vault.backup_vault_id
-  type      = "Microsoft.DataProtection/backupVaults/backupInstances@2025-09-01"
-  body = {
-    properties = {
-      friendlyName = "${module.naming.kubernetes_cluster.name_unique}-backup-instance"
-      objectType   = "BackupInstance"
-      dataSourceInfo = {
-        datasourceType   = "Microsoft.ContainerService/managedClusters"
-        objectType       = "Datasource"
-        resourceID       = azurerm_kubernetes_cluster.example.id
-        resourceLocation = azurerm_resource_group.example.location
-        resourceName     = azurerm_kubernetes_cluster.example.name
-        resourceType     = "Microsoft.ContainerService/managedClusters"
-        resourceUri      = azurerm_kubernetes_cluster.example.id
-      }
-      dataSourceSetInfo = {
-        datasourceType   = "Microsoft.ContainerService/managedClusters"
-        objectType       = "DatasourceSet"
-        resourceID       = azurerm_kubernetes_cluster.example.id
-        resourceLocation = azurerm_resource_group.example.location
-        resourceName     = azurerm_kubernetes_cluster.example.name
-        resourceType     = "Microsoft.ContainerService/managedClusters"
-        resourceUri      = azurerm_kubernetes_cluster.example.id
-      }
-      policyInfo = {
-        policyId = module.backup_vault.kubernetes_backup_policy_ids["aks"]
-        policyParameters = {
-          backupDatasourceParametersList = [
-            {
-              objectType                   = "KubernetesClusterBackupDatasourceParameters"
-              includeClusterScopeResources = true
-              snapshotVolumes              = true
-              excludedNamespaces           = ["kube-system", "kube-public", "kube-node-lease"]
-              excludedResourceTypes        = []
-              includedNamespaces           = []
-              includedResourceTypes        = []
-              labelSelectors               = []
-            }
-          ]
-          dataStoreParametersList = [
-            {
-              objectType      = "AzureOperationalStoreParameters"
-              dataStoreType   = "OperationalStore"
-              resourceGroupId = azurerm_resource_group.snap.id
-            }
-          ]
-        }
-      }
-      validationType = "ShallowValidation"
-    }
-  }
-  ignore_casing             = true
-  ignore_missing_property   = true
-  ignore_null_property      = true
-  schema_validation_enabled = false
-
-  depends_on = [time_sleep.wait_for_rbac]
-
-  lifecycle {
-    ignore_changes = [
-      body.properties.dataSourceInfo.objectType,
-      body.properties.dataSourceSetInfo.objectType,
-    ]
-  }
-}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -334,8 +258,6 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.4)
-
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
 - <a name="requirement_time"></a> [time](#requirement\_time) (>= 0.9.1)
@@ -344,7 +266,6 @@ The following requirements are needed by this module:
 
 The following resources are used by this module:
 
-- [azapi_resource.backup_instance](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
 - [azurerm_kubernetes_cluster.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster) (resource)
 - [azurerm_kubernetes_cluster_extension.backup_extension](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_extension) (resource)
 - [azurerm_kubernetes_cluster_trusted_access_role_binding.backup_access](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_trusted_access_role_binding) (resource)
@@ -355,7 +276,6 @@ The following resources are used by this module:
 - [azurerm_storage_account.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) (resource)
 - [azurerm_storage_container.example](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) (resource)
 - [time_sleep.wait_for_extension](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
-- [time_sleep.wait_for_rbac](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) (resource)
 - [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
 
 <!-- markdownlint-disable MD013 -->

--- a/examples/aks_backup/main.tf
+++ b/examples/aks_backup/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 1.9, < 2.0"
 
   required_providers {
-    azapi = {
-      source  = "Azure/azapi"
-      version = "~> 2.4"
-    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
@@ -21,8 +17,6 @@ provider "azurerm" {
   features {}
   storage_use_azuread = true
 }
-
-provider "azapi" {}
 
 data "azurerm_client_config" "current" {}
 
@@ -133,10 +127,7 @@ resource "azurerm_role_assignment" "extension_storage_access" {
 }
 
 # ---------------------------------------------------------------------------
-# Backup vault + policy (phase 1 — vault MSI must exist before RBAC below)
-# The backup instance is intentionally omitted here so that all required RBAC
-# and the trusted-access binding can be established before the instance is
-# created.  See the azapi_resource.backup_instance block further below.
+# Backup vault + policy + backup instance
 # ---------------------------------------------------------------------------
 module "backup_vault" {
   source = "../../"
@@ -146,6 +137,24 @@ module "backup_vault" {
   name                = "${module.naming.recovery_services_vault.name_unique}-vault"
   redundancy          = "LocallyRedundant"
   resource_group_name = azurerm_resource_group.example.name
+  backup_instances = {
+    aks = {
+      type                         = "kubernetes"
+      name                         = "${module.naming.kubernetes_cluster.name_unique}-backup-instance"
+      backup_policy_key            = "aks"
+      kubernetes_cluster_id        = azurerm_kubernetes_cluster.example.id
+      snapshot_resource_group_name = azurerm_resource_group.snap.name
+      backup_datasource_parameters = {
+        excluded_namespaces              = ["kube-system", "kube-public", "kube-node-lease"]
+        excluded_resource_types          = []
+        included_namespaces              = []
+        included_resource_types          = []
+        label_selectors                  = []
+        cluster_scoped_resources_enabled = true
+        volume_snapshot_enabled          = true
+      }
+    }
+  }
   backup_policies = {
     aks = {
       type = "kubernetes"
@@ -185,7 +194,6 @@ module "backup_vault" {
 
 # ---------------------------------------------------------------------------
 # RBAC — all roles the vault MSI and AKS MSI need for backup operations
-# These must be in place before the backup instance is created.
 # ---------------------------------------------------------------------------
 
 # Grants the backup vault's managed identity operator access to the AKS cluster
@@ -233,88 +241,4 @@ resource "azurerm_role_assignment" "required_roles" {
   principal_id         = each.value.principal_id
   scope                = each.value.scope
   role_definition_name = each.value.role
-}
-
-# Allow RBAC assignments to propagate across Azure AD before creating the
-# backup instance — typically takes up to 2 minutes.
-resource "time_sleep" "wait_for_rbac" {
-  create_duration = "2m"
-
-  depends_on = [
-    azurerm_kubernetes_cluster_trusted_access_role_binding.backup_access,
-    azurerm_role_assignment.extension_storage_access,
-    azurerm_role_assignment.required_roles,
-  ]
-}
-
-# ---------------------------------------------------------------------------
-# Backup instance (phase 2 — created only after all RBAC is in place)
-# ---------------------------------------------------------------------------
-resource "azapi_resource" "backup_instance" {
-  location  = azurerm_resource_group.example.location
-  name      = "${module.naming.kubernetes_cluster.name_unique}-backup-instance"
-  parent_id = module.backup_vault.backup_vault_id
-  type      = "Microsoft.DataProtection/backupVaults/backupInstances@2025-09-01"
-  body = {
-    properties = {
-      friendlyName = "${module.naming.kubernetes_cluster.name_unique}-backup-instance"
-      objectType   = "BackupInstance"
-      dataSourceInfo = {
-        datasourceType   = "Microsoft.ContainerService/managedClusters"
-        objectType       = "Datasource"
-        resourceID       = azurerm_kubernetes_cluster.example.id
-        resourceLocation = azurerm_resource_group.example.location
-        resourceName     = azurerm_kubernetes_cluster.example.name
-        resourceType     = "Microsoft.ContainerService/managedClusters"
-        resourceUri      = azurerm_kubernetes_cluster.example.id
-      }
-      dataSourceSetInfo = {
-        datasourceType   = "Microsoft.ContainerService/managedClusters"
-        objectType       = "DatasourceSet"
-        resourceID       = azurerm_kubernetes_cluster.example.id
-        resourceLocation = azurerm_resource_group.example.location
-        resourceName     = azurerm_kubernetes_cluster.example.name
-        resourceType     = "Microsoft.ContainerService/managedClusters"
-        resourceUri      = azurerm_kubernetes_cluster.example.id
-      }
-      policyInfo = {
-        policyId = module.backup_vault.kubernetes_backup_policy_ids["aks"]
-        policyParameters = {
-          backupDatasourceParametersList = [
-            {
-              objectType                   = "KubernetesClusterBackupDatasourceParameters"
-              includeClusterScopeResources = true
-              snapshotVolumes              = true
-              excludedNamespaces           = ["kube-system", "kube-public", "kube-node-lease"]
-              excludedResourceTypes        = []
-              includedNamespaces           = []
-              includedResourceTypes        = []
-              labelSelectors               = []
-            }
-          ]
-          dataStoreParametersList = [
-            {
-              objectType      = "AzureOperationalStoreParameters"
-              dataStoreType   = "OperationalStore"
-              resourceGroupId = azurerm_resource_group.snap.id
-            }
-          ]
-        }
-      }
-      validationType = "ShallowValidation"
-    }
-  }
-  ignore_casing             = true
-  ignore_missing_property   = true
-  ignore_null_property      = true
-  schema_validation_enabled = false
-
-  depends_on = [time_sleep.wait_for_rbac]
-
-  lifecycle {
-    ignore_changes = [
-      body.properties.dataSourceInfo.objectType,
-      body.properties.dataSourceSetInfo.objectType,
-    ]
-  }
 }


### PR DESCRIPTION




## Description

Refactor the aks_backup example to use the module's `backup_instances` variable instead of a standalone `azapi_resource` block for creating the backup instance.

Previously, the example created the AKS backup instance outside the module using a raw `azapi_resource`, which:
- Bypassed the module's built-in backup instance logic
- Didn't properly test the module's `backup_instances` interface for Kubernetes type
- Required users to understand the low-level Azure REST API body structure

Now the backup instance is created through `module.backup_vault.backup_instances` using the module's variable interface, matching the pattern used by other examples (e.g., `disk_backup`, `blob_storage_backup`).

Also removed the direct `azapi` provider dependency from the example since it's no longer needed.

Follows up on PR #60 review feedback from @Pyodin.

Closes #58
Closes #59

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #58" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks