### PR TITLE
fix: simplify resource guard interface by removing use_external variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ Default: `[]`
 
 ### <a name="input_resource_guard_enabled"></a> [resource\_guard\_enabled](#input\_resource\_guard\_enabled)
 
-Description: Controls whether a Resource Guard association is created for the backup vault. When true, set `resource_guard_use_external = true` and provide `resource_guard_resource_id` to use an existing guard, or leave them unset to create a new guard in the same resource group.
+Description: Controls whether a Resource Guard is associated with the backup vault. When true and `resource_guard_resource_id` is null, a new Resource Guard is created in the same resource group. When true and `resource_guard_resource_id` is provided, the existing external guard is associated instead.
 
 Type: `bool`
 
@@ -434,7 +434,7 @@ Default: `false`
 
 ### <a name="input_resource_guard_name"></a> [resource\_guard\_name](#input\_resource\_guard\_name)
 
-Description: The name of the Resource Guard. If not specified, will use the backup vault name with '-guard' suffix. Only used when creating a new resource guard.
+Description: The name of the Resource Guard. If not specified, will use the backup vault name with '-guard' suffix. Only used when creating a new resource guard (i.e., when `resource_guard_resource_id` is null).
 
 Type: `string`
 
@@ -442,19 +442,11 @@ Default: `null`
 
 ### <a name="input_resource_guard_resource_id"></a> [resource\_guard\_resource\_id](#input\_resource\_guard\_resource\_id)
 
-Description: The resource ID of an existing Resource Guard to associate with the backup vault. Must be set when `resource_guard_use_external = true`.
+Description: The resource ID of an existing Resource Guard to associate with the backup vault. When provided (with `resource_guard_enabled = true`), no new guard is created — the existing one is used directly.
 
 Type: `string`
 
 Default: `null`
-
-### <a name="input_resource_guard_use_external"></a> [resource\_guard\_use\_external](#input\_resource\_guard\_use\_external)
-
-Description: When true, uses an existing external Resource Guard specified by `resource_guard_resource_id` instead of creating a new one. Requires `resource_guard_enabled = true`.
-
-Type: `bool`
-
-Default: `false`
 
 ### <a name="input_retention_duration_in_days"></a> [retention\_duration\_in\_days](#input\_retention\_duration\_in\_days)
 

--- a/main.resource_guard.tf
+++ b/main.resource_guard.tf
@@ -1,7 +1,7 @@
 # Resource Guard for added protection of backup resources
 # Creates a new resource guard only when enabled and no external guard ID is provided
 resource "azapi_resource" "resource_guard" {
-  count = var.resource_guard_enabled && !var.resource_guard_use_external ? 1 : 0
+  count = var.resource_guard_enabled && var.resource_guard_resource_id == null ? 1 : 0
 
   location  = var.location
   name      = coalesce(var.resource_guard_name, "${var.name}-guard")
@@ -36,7 +36,7 @@ resource "azapi_resource" "vault_resource_guard_association" {
   type      = "Microsoft.DataProtection/backupVaults/backupResourceGuardProxies@2025-09-01"
   body = {
     properties = {
-      resourceGuardResourceId = var.resource_guard_use_external ? var.resource_guard_resource_id : azapi_resource.resource_guard[0].id
+      resourceGuardResourceId = var.resource_guard_resource_id != null ? var.resource_guard_resource_id : azapi_resource.resource_guard[0].id
     }
   }
   create_headers            = var.enable_telemetry ? { "User-Agent" = local.avm_azapi_header } : null

--- a/variables.resourceguard.tf
+++ b/variables.resourceguard.tf
@@ -1,13 +1,13 @@
 variable "resource_guard_enabled" {
   type        = bool
   default     = false
-  description = "Controls whether a Resource Guard association is created for the backup vault. When true, set `resource_guard_use_external = true` and provide `resource_guard_resource_id` to use an existing guard, or leave them unset to create a new guard in the same resource group."
+  description = "Controls whether a Resource Guard is associated with the backup vault. When true and `resource_guard_resource_id` is null, a new Resource Guard is created in the same resource group. When true and `resource_guard_resource_id` is provided, the existing external guard is associated instead."
 }
 
 variable "resource_guard_name" {
   type        = string
   default     = null
-  description = "The name of the Resource Guard. If not specified, will use the backup vault name with '-guard' suffix. Only used when creating a new resource guard."
+  description = "The name of the Resource Guard. If not specified, will use the backup vault name with '-guard' suffix. Only used when creating a new resource guard (i.e., when `resource_guard_resource_id` is null)."
 
   validation {
     condition = (
@@ -24,7 +24,7 @@ variable "resource_guard_name" {
 variable "resource_guard_resource_id" {
   type        = string
   default     = null
-  description = "The resource ID of an existing Resource Guard to associate with the backup vault. Must be set when `resource_guard_use_external = true`."
+  description = "The resource ID of an existing Resource Guard to associate with the backup vault. When provided (with `resource_guard_enabled = true`), no new guard is created — the existing one is used directly."
 
   validation {
     condition = (
@@ -33,12 +33,6 @@ variable "resource_guard_resource_id" {
     )
     error_message = "If provided, resource_guard_resource_id must be a valid Azure resource ID for a Microsoft.DataProtection/resourceGuards resource."
   }
-}
-
-variable "resource_guard_use_external" {
-  type        = bool
-  default     = false
-  description = "When true, uses an existing external Resource Guard specified by `resource_guard_resource_id` instead of creating a new one. Requires `resource_guard_enabled = true`."
 }
 
 variable "vault_critical_operation_exclusion_list" {


### PR DESCRIPTION
## Summary

Follow-up to #70. Simplifies the resource guard interface by removing the `resource_guard_use_external` boolean — behavior is now inferred directly from `resource_guard_resource_id`:

- `resource_guard_resource_id = null` → creates a new Resource Guard in the same RG
- `resource_guard_resource_id = "/subscriptions/.../resourceGuards/my-guard"` → associates the existing external guard

No extra boolean needed. This aligns with standard AVM patterns where providing an ID implies using an existing resource.

## Changes

- `variables.resourceguard.tf`: Removed `resource_guard_use_external` variable, updated descriptions
- `main.resource_guard.tf`: Simplified count/ternary logic
- `README.md`: Auto-regenerated by terraform-docs

## Validation

- `./avm pre-commit` pass
- Unit tests (9/9) pass
- E2E sandbox: apply → idempotent (0 changes) → destroy pass