### PR TITLE
chore: combine CodeQL action 4.36.3 updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,11 +36,11 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Combines the Dependabot CodeQL action updates into one PR so `init` and `analyze` run the same CodeQL Action version.

The separate Dependabot PRs fail because one step loads CodeQL Action 4.36.3 configuration while the other still runs 4.36.2:

> Loaded a configuration file for version '4.36.3', but running version '4.36.2'

This PR updates both `github/codeql-action/init` and `github/codeql-action/analyze` to the same 4.36.3 SHA.

Related Dependabot PRs: #100, #101.